### PR TITLE
fix: theme dropdown closes when click outside the box

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -12,6 +12,20 @@ toolbarThemes.addEventListener('click', event => {
   themeList.classList.toggle('open');
 });
 
+document.addEventListener("mouseup", function (e) {
+  const target = document.querySelector('.toolbar__themes.open');
+  const toolbarThemes = document.querySelector('.toolbar-option.themes');
+
+  if (!target) {
+    return;
+  }
+
+  if (e.target.className !== toolbarThemes.className) {
+    target.classList.remove("open");
+  }
+  return;
+});
+
 toolbarClear.addEventListener('click', event => {
   event.preventDefault();
   


### PR DESCRIPTION
When the theme's  dropdown is opened and there's a click outside the box, or in one option, or in the theme button then the box will closes