### PR TITLE
Overflow resolve

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     </nav>
     <div id="screen">
       <span class="screen__staged"></span>
-      <span class="screen__current"></span>
+      <span class="screen__current" style="margin-right: -10px;"></span>
     </div>
     <section id="buttons">
       <section class="numbers">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,10 +127,10 @@ a:hover {
   font-size: 1rem;
 }
 
-#screen .screen__current {
+/* #screen .screen__current {
   height: 45px;
   font-size: 2rem;
-}
+} */
 
 #buttons {
   display: flex;
@@ -182,3 +182,23 @@ button {
     width: 335px;
   }
 }
+
+
+
+
+/* media query for overflowing answer text */
+/* media query for overflowing answer text */
+@media only screen and (max-width: 400px){
+  #screen .screen__current {
+    height: 45px;
+    font-size: 1.4rem;
+  }
+}
+
+@media only screen and (min-width: 401px){
+  #screen .screen__current {
+    height: 45px;
+    font-size: 1.7rem;
+  }
+}
+


### PR DESCRIPTION
The answers overflowing if the digits in it were 16 or more are now not overflowing.
This calculator is responsible for a minimum width of 300 px, so there is nothing overflowing until 300 px.
I also have used media queries for the change in text size for overflowing texts